### PR TITLE
Resource ID should be type string

### DIFF
--- a/protos/bottle/fulfillment/v1/order.proto
+++ b/protos/bottle/fulfillment/v1/order.proto
@@ -7,7 +7,7 @@ import "bottle/catalog/v1/product.proto";
 import "bottle/account/v1/user.proto";
 
 message Order {
-  int64 id = 1;
+  string id = 1;
 
   bottle.account.v1.User customer = 2;
   bottle.account.v1.Address shipping = 3;


### PR DESCRIPTION
As we move more into event based architecture we'll need to leverage UUIDs more and more for our PKs. Setting all the IDs to string now is a good way to get us ready for that. This one was missed before.