### PR TITLE
Wrap resources with timestamp and id

### DIFF
--- a/protos/bottle/core/v1/case.proto
+++ b/protos/bottle/core/v1/case.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package bottle.core.v1;
+
+import "bottle/fulfillment/v1/order.proto";
+
+message Case {
+  int64 timestamp = 1;
+  string request_id = 2;
+  string source = 3;
+
+  oneof bottle {
+    bottle.fulfillment.v1.Order order = 4;
+  }
+}

--- a/protos/bottle/core/v1/message.proto
+++ b/protos/bottle/core/v1/message.proto
@@ -4,12 +4,12 @@ package bottle.core.v1;
 
 import "bottle/fulfillment/v1/order.proto";
 
-message Case {
+message Message {
   int64 timestamp = 1;
   string request_id = 2;
   string source = 3;
 
-  oneof bottle {
+  oneof resource {
     bottle.fulfillment.v1.Order order = 4;
   }
 }


### PR DESCRIPTION
The goal here is to allow us to pass along the `requestId` from the web layer so we can trace requests. We also include a `source` and a `timestamp` for good record keeping.