### PR TITLE
only rm the *.pb.ex files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Generate
         run: |
-          rm -rf ./elixir/lib/**/*.pb.ex
+          find ./elixir/lib/ -type f -name '*.pb.ex' -delete
 
           cp -R ./current/protos/. ./elixir/priv/protos/
           cd ./elixir/priv/protos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,7 @@ jobs:
 
       - name: Generate
         run: |
-          rm -rf ./elixir/lib
-          mkdir ./elixir/lib
+          rm -rf ./elixir/lib/**/*.pb.ex
 
           cp -R ./current/protos/. ./elixir/priv/protos/
           cd ./elixir/priv/protos

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,8 +55,7 @@ jobs:
 
       - name: Generate
         run: |
-          rm -rf ./elixir/lib
-          mkdir ./elixir/lib
+          rm -rf ./elixir/lib/**/*.pb.ex
 
           cp -R ./master/protos/. ./elixir/priv/protos/
           cd ./elixir/priv/protos

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Generate
         run: |
-          rm -rf ./elixir/lib/**/*.pb.ex
+          find ./elixir/lib/ -type f -name '*.pb.ex' -delete
 
           cp -R ./master/protos/. ./elixir/priv/protos/
           cd ./elixir/priv/protos


### PR DESCRIPTION
Only removes the generated protobuf files in the elixir branch. This does not delete the folders, but I think that should be fine.