### PR TITLE
Remove extraneous phone number

### DIFF
--- a/protos/bottle/account/v1/events.proto
+++ b/protos/bottle/account/v1/events.proto
@@ -21,7 +21,6 @@ message PasswordReset {
 message TwoFactorRequested {
   bottle.account.v1.User user = 1;
   string token = 2;
-  string phone_number = 3;
 
   enum TwoFactorMethod {
     TWO_FACTOR_METHOD_UNSPECIFIED = 0;
@@ -29,7 +28,7 @@ message TwoFactorRequested {
     TWO_FACTOR_METHOD_VOICE = 2;
   }
 
-  string method = 4;
+  string method = 3;
 }
 
 message TwoFactorRecoveryCodeUsed {


### PR DESCRIPTION
This is a breaking change but we haven't yet used it. As I was implementing this change I noticed we had duplicated the phone number field. This removes it as it is not currently necessary on this message since it's also included in the user.