### PR TITLE
Support filtering by status

### DIFF
--- a/protos/bottle/assembly/v1/service.proto
+++ b/protos/bottle/assembly/v1/service.proto
@@ -6,6 +6,8 @@ package bottle.assembly.v1;
 
 message BuildListRequest {
   string request_id = 1;
+
+  repeated Build.BuildStatus status = 2;
 }
 
 message BuildListResponse {


### PR DESCRIPTION
For the Assembly Service's gRPC call we need filter the requested builds otherwise we're going to end up with way more than we need.

Open to suggestions. I'm on the fence about whether we should allow multiple statuses to be requested at once or request multiple gRPC calls. For this MVP we don't need to worry about showing all the built builds but when we do get to that phase, we'll need to consider pagination for our gRPC calls.