### PR TITLE
remove tax exempt bool from fulfillment orders

### DIFF
--- a/protos/bottle/fulfillment/v1/order.proto
+++ b/protos/bottle/fulfillment/v1/order.proto
@@ -35,6 +35,5 @@ message Order {
   PaymentMethod payment_method = 7;
   string scode = 8;
 
-  bool tax_exempt = 9;
   repeated TaxLine tax_lines = 10;
 }


### PR DESCRIPTION
Tax exemption is now handled 100% by our tax service, so we don't need to track it on orders