### PR TITLE
Setup messages for async order validation

### DIFF
--- a/protos/bottle/core/v1/bottle.proto
+++ b/protos/bottle/core/v1/bottle.proto
@@ -15,8 +15,9 @@ message Bottle {
 
   oneof resource {
     bottle.fulfillment.v1.OrderCreated order_created = 4;
-    bottle.fulfillment.v1.VerificationRequested verification_requested = 5;
     bottle.fulfillment.v1.TribbleFailed tribble_failed = 6;
+    bottle.fulfillment.v1.ValidationRequest validation_request = 22;
+    bottle.fulfillment.v1.ValidationResponse validation_response = 23;
 
     bottle.account.v1.UserCreated user_created = 7;
     bottle.account.v1.UserDeleted user_deleted = 20;

--- a/protos/bottle/core/v1/bottle.proto
+++ b/protos/bottle/core/v1/bottle.proto
@@ -5,6 +5,7 @@ package bottle.core.v1;
 import "bottle/account/v1/events.proto";
 import "bottle/assembly/v1/events.proto";
 import "bottle/fulfillment/v1/events.proto";
+import "bottle/fulfillment/v1/order_verification_service.proto";
 import "bottle/inventory/v1/events.proto";
 import "bottle/support/v1/events.proto";
 
@@ -15,9 +16,9 @@ message Bottle {
 
   oneof resource {
     bottle.fulfillment.v1.OrderCreated order_created = 4;
+    bottle.fulfillment.v1.OrderVerificationRequest order_verification_request = 22;
+    bottle.fulfillment.v1.OrderVerificationResponse order_verification_response = 23;
     bottle.fulfillment.v1.TribbleFailed tribble_failed = 6;
-    bottle.fulfillment.v1.ValidationRequest validation_request = 22;
-    bottle.fulfillment.v1.ValidationResponse validation_response = 23;
 
     bottle.account.v1.UserCreated user_created = 7;
     bottle.account.v1.UserDeleted user_deleted = 20;

--- a/protos/bottle/fulfillment/v1/events.proto
+++ b/protos/bottle/fulfillment/v1/events.proto
@@ -8,11 +8,6 @@ message OrderCreated {
   bottle.fulfillment.v1.Order order = 1;
 }
 
-message VerificationRequested {
-  bottle.fulfillment.v1.Order order = 1;
-  repeated string flags = 2;
-}
-
 message TribbleFailed {
   bottle.fulfillment.v1.Order order = 1;
 

--- a/protos/bottle/fulfillment/v1/order_verification_service.proto
+++ b/protos/bottle/fulfillment/v1/order_verification_service.proto
@@ -5,11 +5,11 @@ import "bottle/fulfillment/v1/tax_line.proto";
 
 package bottle.fulfillment.v1;
 
-message ValidationRequest {
+message OrderVerificationRequest {
   bottle.fulfillment.v1.Order order = 1;
 }
 
-message ValidationResponse {
+message OrderVerificationResponse {
   bottle.fulfillment.v1.Order order = 1;
   repeated string flags = 2;
 }

--- a/protos/bottle/fulfillment/v1/validation_service.proto
+++ b/protos/bottle/fulfillment/v1/validation_service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+import "bottle/fulfillment/v1/order.proto";
+import "bottle/fulfillment/v1/tax_line.proto";
+
+package bottle.fulfillment.v1;
+
+message ValidationRequest {
+  bottle.fulfillment.v1.Order order = 1;
+}
+
+message ValidationResponse {
+  bottle.fulfillment.v1.Order order = 1;
+  repeated string flags = 2;
+}


### PR DESCRIPTION
This adds the needed bottle messages to move Hal and LP to async order validation over RabbitMQ.

This is a little different than what we normally do. First off, I wrote this like a grpc service. We make a request, and we expect a response. The only difference being this is async over rabbitmq instead of over grpc. Because of that, I put the two messages in their own file, and named them `OrderVerificationRequest` instead of the past tense `OrderVerificationRequested` like what we do with events. Interested in your thoughts about this request vs event naming @doomspork 