### PR TITLE
add order updated message

### DIFF
--- a/protos/bottle/core/v1/bottle.proto
+++ b/protos/bottle/core/v1/bottle.proto
@@ -15,6 +15,7 @@ message Bottle {
 
   oneof resource {
     bottle.fulfillment.v1.OrderCreated order_created = 4;
+    bottle.fulfillment.v1.OrderUpdated order_updated = 22;
     bottle.fulfillment.v1.VerificationRequested verification_requested = 5;
     bottle.fulfillment.v1.TribbleFailed tribble_failed = 6;
 

--- a/protos/bottle/fulfillment/v1/events.proto
+++ b/protos/bottle/fulfillment/v1/events.proto
@@ -8,6 +8,11 @@ message OrderCreated {
   bottle.fulfillment.v1.Order order = 1;
 }
 
+message OrderUpdated {
+  bottle.fulfillment.v1.Order old = 1;
+  bottle.fulfillment.v1.Order new = 2;
+}
+
 message VerificationRequested {
   bottle.fulfillment.v1.Order order = 1;
   repeated string flags = 2;


### PR DESCRIPTION
I believe this is the way we discussed about handling updated records moving forward. Basically the update function in what ever the main persistence service would emit the old record and the updated record and any service listening in would do what ever compare it needs to.