### PR TITLE
add an order status enum

### DIFF
--- a/protos/bottle/fulfillment/v1/order.proto
+++ b/protos/bottle/fulfillment/v1/order.proto
@@ -11,6 +11,12 @@ import "bottle/fulfillment/v1/tax_line.proto";
 message Order {
   string id = 1;
 
+  enum Status {
+    STATUS_UNSPECIFIED = 0;
+    STATUS_COMPLETE = 1;
+  }
+  Status status = 13;
+
   bottle.account.v1.User customer = 2;
   bottle.account.v1.Address shipping = 3;
   bottle.account.v1.Address billing = 4;


### PR DESCRIPTION
This adds an order status field. I only included the `STATUS_COMPLETE` value for `fully_shipped` in the database, and `STATUS_UNSPECIFIED` for everything else. From this we can hit the Avalara [CreateOrAdjustTransaction](https://developer.avalara.com/api-reference/avatax/rest/v2/methods/Transactions/CreateOrAdjustTransaction/) when ever an order gets updated from `not :status_complete` to `:status_complete`. Keeping in mind that this won't update anything that goes into return expecting that accounting will need to deal with that themselves (for now)

I named it `STATUS_COMPLETE` instead of `STATUS_SHIPPED` because it feels more accurate from an accounting perspective, an order can be complete without being "shipped", and just because "shipped" feels like it should be on individual products or packages or what ever we decide later down the road.