### PR TITLE
add extended warranty to catalog addon

### DIFF
--- a/protos/bottle/catalog/v1/addon.proto
+++ b/protos/bottle/catalog/v1/addon.proto
@@ -8,6 +8,7 @@ message Addon {
     ADDON_CATEGORY_RUSH_ASSEMBLY = 1;
     ADDON_CATEGORY_HANDLING = 2;
     ADDON_CATEGORY_EWASTE = 3;
+    ADDON_CATEGORY_EXTENDED_WARRANTY = 4;
   }
   AddonCategory category = 1;
 }


### PR DESCRIPTION
`EXTENDED_WARRANTY` over `WARRANTY` because we technically already include a warranty on all products and what the user selects is technically an extended warranty.