### PR TITLE
Add support for RMA descriptions

### DIFF
--- a/protos/bottle/inventory/v1/part.proto
+++ b/protos/bottle/inventory/v1/part.proto
@@ -10,4 +10,5 @@ message Part {
   string serial_number = 2;
   bottle.inventory.v1.Sku sku = 3;
   bottle.inventory.v1.Location location = 4;
+  string rma_description = 5;
 }


### PR DESCRIPTION
We need a way to mark a part as being RMA'd in the messages. I'm open to alternatives, this is just the simplest solution that matches up to our existing inventory requirement.