### PR TITLE
Add shipping to AddonCategory

### DIFF
--- a/protos/bottle/catalog/v1/addon.proto
+++ b/protos/bottle/catalog/v1/addon.proto
@@ -9,6 +9,7 @@ message Addon {
     ADDON_CATEGORY_HANDLING = 2;
     ADDON_CATEGORY_EWASTE = 3;
     ADDON_CATEGORY_EXTENDED_WARRANTY = 4;
+    ADDON_CATEGORY_SHIPPING = 5;
   }
   AddonCategory category = 1;
 }


### PR DESCRIPTION
This is needed for the Canada shipping warranty which should fall under shipping according to Matt