### PR TITLE
add repeated event message to order

### DIFF
--- a/protos/bottle/fulfillment/v1/event.proto
+++ b/protos/bottle/fulfillment/v1/event.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package bottle.fulfillment.v1;
+
+message Event {
+  enum Event {
+    EVENT_UNSPECIFIED = 0;
+    EVENT_FULLY_SHIPPED = 1;
+  }
+
+  Event event = 1;
+  string occured_at = 2;
+}

--- a/protos/bottle/fulfillment/v1/order.proto
+++ b/protos/bottle/fulfillment/v1/order.proto
@@ -5,6 +5,7 @@ package bottle.fulfillment.v1;
 import "bottle/account/v1/address.proto";
 import "bottle/account/v1/user.proto";
 import "bottle/catalog/v1/product.proto";
+import "bottle/fulfillment/v1/event.proto";
 import "bottle/fulfillment/v1/line_item.proto";
 import "bottle/fulfillment/v1/tax_line.proto";
 
@@ -42,4 +43,6 @@ message Order {
   string scode = 8;
 
   repeated TaxLine tax_lines = 10;
+
+  repeated Event events = 14;
 }


### PR DESCRIPTION
This is the start of adding timeline data to an order. This will eventually replace how we currently use messages on orders. Currently only does a message when the order is fully shipped.