### PR TITLE
add section about proto patterns we use to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ end
 
 ## Developing
 
+### Patterns
+
+- ID - When using an ID in a message, we will use a nested record instead. For example, if you wanted to pass an ID
+for an order, we would use `order: %Order{id: "1234"}` instead of `order_id: "1234"`.
+
+- Date & Time - We use string fields to represent ISO 8601 formatted date and time fields. This is built into most
+languages by default, and if you are using elixir, you can simply use `DateTime.to_iso8601/1`.
+
+### Deploying
+
 To change a schema, simply open a PR to `master`. Once approved and merged,
 CI/CD will do the heavy lifting and compile them to each language and push to
 respective branch.


### PR DESCRIPTION
This adds a little bit of documentation to the readme about some patterns we use in our bottles. Mostly for onlookers, but also so I don't have to go digging for how to store datetimes.