### PR TITLE
Add missing_components to Build

### DIFF
--- a/protos/bottle/assembly/v1/build.proto
+++ b/protos/bottle/assembly/v1/build.proto
@@ -24,6 +24,7 @@ message Build {
   }
 
   repeated BuildComponent build_components = 3;
+  repeated BuildComponent missing_components = 8;
 
   string model = 4;
   bottle.fulfillment.v1.Order order = 5;


### PR DESCRIPTION
We need to provide a mechanism to package up and return these to the other services. We could create a new gRPC endpoint and message to handle just these specific components or by adding it here, we can return it in the existing gRPC call.