### PR TITLE
Add event for component kits changed

### DIFF
--- a/protos/bottle/inventory/v1/events.proto
+++ b/protos/bottle/inventory/v1/events.proto
@@ -27,3 +27,7 @@ message PartUpdated {
   bottle.inventory.v1.Part old = 1;
   bottle.inventory.v1.Part new = 2;
 }
+
+message ComponentKitChanged {
+  bottle.inventory.v1.Component component = 1;
+}


### PR DESCRIPTION
Adds new message that will be sent from HAL to Warehouse when component kits change. It will allow to reload the state inside the Components GenServer without having to poll the Database for updates. the flow looks like:

```ascii
                                                ComponentKitChanged  +---------------+
                                               +-------------------->|               |
                                               |                     |   Warehouse   |
                                               |                     |               |
                                               |                     +-------+-------+
                                               |                             |
+-----------+     +--------+           +-------+-----+                       |
|           |     |        |           |             |                       |
|  LCARS    +---->|  HAL   +---------->| RabbitMQ    |                       |  GetComponentDemands
|           |     |        |           |             |                       |
+-----------+     +--------+           +-------------+                       |
                                                                             v
                                                                    +---------------+
                                                                    |               |
                                                                    |   Assembly    |
                                                                    |               |
                                                                    +---------------+
```

