### PR TITLE
explicitly define protobuf version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           cd ./elixir
           mix deps.get
           mix compile
-          mix escript.install --force hex protobuf
+          mix escript.install --force hex protobuf 0.11.0
 
           sudo cp /home/runner/.mix/escripts/protoc-gen-elixir /usr/local/bin/
           sudo chmod +x /usr/local/bin/protoc-gen-elixir

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
           cd ./elixir
           mix deps.get
           mix compile
-          mix escript.install --force hex protobuf
+          mix escript.install --force hex protobuf 0.11.0
 
           sudo cp /home/runner/.mix/escripts/protoc-gen-elixir /usr/local/bin/
           sudo chmod +x /usr/local/bin/protoc-gen-elixir


### PR DESCRIPTION
Generated code should use the same protobuf version defined in mix.exs on the elixir branch:
https://github.com/system76/bottle/pull/87